### PR TITLE
Remove short URL expiry and slug options

### DIFF
--- a/generator.html
+++ b/generator.html
@@ -125,32 +125,6 @@
                                     <input type="text" id="desc" name="desc" class="form-control" placeholder="例：UNIDOL画像用、プロフィール画像用">
                                     <div class="form-text">用途や目的を記入すると管理しやすくなります</div>
                                 </div>
-
-                                <!-- 有効期限 -->
-                                <div class="mb-4">
-                                    <label for="expiredHours" class="form-label fw-semibold">⏰ 有効期限 (時間)</label>
-                                    <input type="number" id="expiredHours" name="expiredHours" class="form-control" value="24" min="0" max="8760">
-                                    <div class="form-text">0を入力すると無期限になります (最大365日)</div>
-                                </div>
-
-                                <!-- カスタムスラッグ -->
-                                <div class="mb-4">
-                                    <label class="form-label fw-semibold">🏷️ カスタムスラッグ</label>
-                                    <div class="d-flex gap-3">
-                                        <div class="form-check">
-                                            <input class="form-check-input" type="radio" id="slugVillage" name="slugType" value="village-se">
-                                            <label class="form-check-label" for="slugVillage">village-se</label>
-                                        </div>
-                                        <div class="form-check">
-                                            <input class="form-check-input" type="radio" id="slugMk" name="slugType" value="mk">
-                                            <label class="form-check-label" for="slugMk">mk</label>
-                                        </div>
-                                        <div class="form-check">
-                                            <input class="form-check-input" type="radio" id="slugAuto" name="slugType" value="auto" checked>
-                                            <label class="form-check-label" for="slugAuto">自動生成</label>
-                                        </div>
-                                    </div>
-                                </div>
                             </div>
                         </div>
                     </form>
@@ -188,15 +162,15 @@
                         </div>
                         <div class="info-item">
                             <h3>🔗 短縮URL</h3>
-                            <p>生成されたURLを短縮して、共有しやすくします。有効期限の設定も可能です。</p>
+                            <p>生成されたURLを短縮して、共有しやすくします。</p>
                         </div>
                         <div class="info-item">
                             <h3>📱 共有機能</h3>
                             <p>作成したURLは簡単にコピー・共有でき、同じ条件での変換を他の人と共有できます。</p>
                         </div>
                         <div class="info-item">
-                            <h3>⏰ 期限管理</h3>
-                            <p>URLの有効期限を設定でき、期限切れ後は専用ページにリダイレクトされます。</p>
+                            <h3>📝 情報整理</h3>
+                            <p>用途や目的などの説明を添えて短縮URLを管理できます。</p>
                         </div>
                     </div>
 
@@ -219,8 +193,8 @@
                                     <ul class="list-unstyled small">
                                         <li>📝 <strong>自動生成:</strong> 設定変更で即座にURL更新</li>
                                         <li>🔗 <strong>短縮URL:</strong> Short.io APIで短縮リンク作成</li>
-                                        <li>⏰ <strong>有効期限:</strong> 1時間〜365日、または無期限</li>
                                         <li>📋 <strong>簡単共有:</strong> ワンクリックでコピー可能</li>
+                                        <li>📝 <strong>説明付き:</strong> 用途メモをURLに添付</li>
                                     </ul>
                                 </div>
                             </div>
@@ -274,8 +248,8 @@
                                     <h6>URL仕様</h6>
                                     <ul class="small">
                                         <li><strong>短縮サービス:</strong> Short.io API</li>
-                                        <li><strong>有効期限:</strong> 最大365日</li>
-                                        <li><strong>カスタムスラッグ:</strong> 対応</li>
+                                        <li><strong>期限切れ時リダイレクト:</strong> 専用ページに転送</li>
+                                        <li><strong>説明:</strong> 任意のテキストを設定可能</li>
                                     </ul>
                                 </div>
                             </div>

--- a/generator.html
+++ b/generator.html
@@ -21,7 +21,7 @@
                     </div>
 
                     <!-- ナビゲーション -->
-                    <nav class="d-flex justify-content-center mb-4">
+                    <!-- <nav class="d-flex justify-content-center mb-4">
                         <ul class="nav nav-pills">
                             <li class="nav-item">
                                 <a class="nav-link" href="index.html">📸 変換ツール</a>
@@ -33,7 +33,7 @@
                                 <a class="nav-link" href="expired.html">ℹ️ 期限切れページ</a>
                             </li>
                         </ul>
-                    </nav>
+                    </nav> -->
 
                     <!-- 設定フォーム -->
                     <form id="paramForm">
@@ -122,7 +122,7 @@
                                 <!-- 説明 -->
                                 <div class="mb-4">
                                     <label for="desc" class="form-label fw-semibold">📝 説明 (任意)</label>
-                                    <input type="text" id="desc" name="desc" class="form-control" placeholder="例：UNIDOL画像用、プロフィール画像用">
+                                    <input type="text" id="desc" name="desc" class="form-control" placeholder="例：配信画像用、プロフィール画像用">
                                     <div class="form-text">用途や目的を記入すると管理しやすくなります</div>
                                 </div>
                             </div>
@@ -155,7 +155,7 @@
                     </div>
 
                     <!-- 機能説明 -->
-                    <div class="info-grid">
+                    <!-- <div class="info-grid">
                         <div class="info-item">
                             <h3>⚙️ 条件設定</h3>
                             <p>画像の比率、サイズ、形式などを詳細に設定して、専用の変換URLを生成できます。</p>
@@ -172,10 +172,10 @@
                             <h3>📝 情報整理</h3>
                             <p>用途や目的などの説明を添えて短縮URLを管理できます。</p>
                         </div>
-                    </div>
+                    </div> -->
 
                     <!-- 使用方法ガイド -->
-                    <div class="card mt-4">
+                    <!-- <div class="card mt-4">
                         <div class="card-body">
                             <h5 class="card-title">📖 使用方法ガイド</h5>
                             <div class="row">
@@ -199,10 +199,10 @@
                                 </div>
                             </div>
                         </div>
-                    </div>
+                    </div> -->
 
                     <!-- 活用例 -->
-                    <div class="card mt-4">
+                    <!-- <div class="card mt-4">
                         <div class="card-body">
                             <h5 class="card-title">💡 活用例</h5>
                             <div class="row">
@@ -229,10 +229,10 @@
                                 </div>
                             </div>
                         </div>
-                    </div>
+                    </div> -->
 
                     <!-- 技術仕様 -->
-                    <div class="card mt-4">
+                    <!-- <div class="card mt-4">
                         <div class="card-body">
                             <h5 class="card-title">🔧 技術仕様</h5>
                             <div class="row">
@@ -254,6 +254,20 @@
                                 </div>
                             </div>
                         </div>
+                    </div> -->
+
+                    <!-- フッター -->
+                    <div class="footer">
+                        <p class="mt-3">
+                            <small class="text-muted">
+                                🛡️ プライバシー保護のため、アップロードされた画像はサーバーに保存されません。<br>
+                                すべての処理はお使いのブラウザ内で完了します。
+                            </small>
+                        </p>
+                        <p class="text-muted mb-0">
+                            <strong>画像条件便</strong> - 画像ファイル変換サービス<br>
+                            <small>© 2025 画像条件便. All rights reserved.</small>
+                        </p>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -141,6 +141,20 @@
                             <p>自動切り取りだけでなく、手動で範囲を指定した精密な切り取りも可能です。</p>
                         </div>
                     </div> -->
+
+                    <!-- フッター -->
+                    <div class="footer">
+                        <p class="mt-3">
+                            <small class="text-muted">
+                                🛡️ プライバシー保護のため、アップロードされた画像はサーバーに保存されません。<br>
+                                すべての処理はお使いのブラウザ内で完了します。
+                            </small>
+                        </p>
+                        <p class="text-muted mb-0">
+                            <strong>画像条件便</strong> - 画像ファイル変換サービス<br>
+                            <small>© 2025 画像条件便. All rights reserved.</small>
+                        </p>
+                    </div>
                 </div>
             </div>
         </div>

--- a/main.js
+++ b/main.js
@@ -920,8 +920,7 @@ async function createShortUrl() {
 
         const requestBody = {
             domain: SHORT_IO_DOMAIN,
-            originalURL: currentLongUrl,
-            expiredURL: expiredUrl
+            originalURL: currentLongUrl
         };
 
         if (desc) {

--- a/main.js
+++ b/main.js
@@ -928,16 +928,13 @@ async function createShortUrl() {
             requestBody.title = desc;
         }
 
-        const slugType = formData.get('slugType');
-        if (slugType && slugType !== 'auto') {
-            requestBody.path = slugType;
-        }
-
-        const expiredHours = parseInt(formData.get('expiredHours'), 10) || 0;
-        if (expiredHours > 0) {
-            const expiresAt = new Date(Date.now() + expiredHours * 60 * 60 * 1000);
-            requestBody.expiresAt = expiresAt.toISOString();
-        }
+        const safeDesc = desc
+            ? desc.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            : '設定なし';
+        const safeExpiredUrl = expiredUrl.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        const safeOriginalUrl = currentLongUrl
+            ? currentLongUrl.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            : '';
 
         const response = await fetch(SHORT_IO_ENDPOINT, {
             method: 'POST',
@@ -954,7 +951,6 @@ async function createShortUrl() {
 
         if (response.ok && responseData.shortURL) {
             const shortUrl = responseData.secureShortURL || responseData.shortURL;
-            const resolvedSlug = slugType === 'auto' ? (responseData.path || '自動生成') : slugType;
 
             resultSection.innerHTML = `
                 <div class="alert alert-success" role="alert">
@@ -978,9 +974,9 @@ async function createShortUrl() {
                         <div class="card-body">
                             <h6 class="card-title">設定詳細</h6>
                             <ul class="list-unstyled mb-0">
-                                <li><strong>有効期限:</strong> ${expiredHours > 0 ? `${expiredHours}時間` : '無期限'}</li>
-                                <li><strong>スラッグ:</strong> ${resolvedSlug}</li>
-                                <li><strong>期限切れ後の転送先:</strong> <small>${expiredUrl}</small></li>
+                                ${safeOriginalUrl ? `<li><strong>短縮対象URL:</strong> <small>${safeOriginalUrl}</small></li>` : ''}
+                                <li><strong>説明:</strong> ${desc ? safeDesc : '設定なし'}</li>
+                                <li><strong>期限切れ後の転送先:</strong> <small>${safeExpiredUrl}</small></li>
                             </ul>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- remove the expiration and custom slug fields from the generator form and related descriptions
- simplify the short URL creation logic to drop expiry and slug handling while enhancing the result details

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3d0762410832e95cebfe5be40ec3f